### PR TITLE
Added optional talent panel from Details.

### DIFF
--- a/Examiner.lua
+++ b/Examiner.lua
@@ -182,6 +182,12 @@ end
 function ex:PLAYER_TARGET_CHANGED(event)
 	if (cfg.autoInspect) and (UnitExists("target")) then
 		self:DoInspect("target");
+			if _G.Details and (UnitIsPlayer("target")) then
+				InspectFrame = Examiner
+				Details:ShowTalentsPanel()
+			elseif _G.Details then
+				DetailsTalentFrame:Hide();
+			end
 	elseif (self.unit == "target") then
 		self.unit = nil;
 		self:SetScript("OnUpdate",nil);
@@ -747,6 +753,12 @@ function ex:DoInspect(unit,openFlag)
 		-- We couldn't Inspect, try and see if we have them cached?
 		if (not self.canInspect) and (not self:LoadPlayerFromCache(self:GetEntryName())) and (cfg.activePage) then
 			self.modules[cfg.activePage].page:Hide();	-- Az: this is slightly bad to do, what if a module still have data to show? feats still work outside inspect range for example
+		end
+		-- show talents
+		if (openFlag ~= false) and _G.Details and (UnitIsPlayer("target")) and (not self:IsShown()) then
+    		self:Display();
+    		InspectFrame = Examiner
+    		Details:ShowTalentsPanel()
 		end
 		-- Outside range, monitor range and inspect as soon as they are in range
 		if (not CheckInteractDistance(unit,3)) then

--- a/Examiner.toc
+++ b/Examiner.toc
@@ -4,6 +4,7 @@
 ## Author: Aezay (Earthen Ring EU), Grome (Sulfuron)
 ## Notes: Advanced Inspection Mod of Gear and Honor.
 ## SavedVariables: Examiner_Config, Examiner_Cache
+## OptionalDeps: Details
 
 ## libs ##
 LibGearExam\LibGearExam.xml


### PR DESCRIPTION
Improved Details talent panel code from this issue: https://github.com/taxidriveer/Examiner/issues/12.
Added checks for NPCs so it won't request talent data if you target NPCs. Made talent panel close if you target NPC with inspection panel open.
Added checks to make Details optional. Previous code caused errors if you didn't have details installed.

For those who don't use details, won't notice any difference with this update.

This is how examiner looks like with this update and when using Details:
![WowClassic_Y6izQiUefA](https://user-images.githubusercontent.com/57199053/97514906-2748ce80-1990-11eb-9d97-748ab024b7fc.png)